### PR TITLE
Add Joke Count to Home Page

### DIFF
--- a/src/web/Data/Repositories/IJokeRepository.cs
+++ b/src/web/Data/Repositories/IJokeRepository.cs
@@ -24,6 +24,14 @@ public interface IJokeRepository
     IQueryable<Joke> ListAll(string activeInd = "Y", string requestingUserName = "ANON");
 
     /// <summary>
+    /// Gets the count of joke records.
+    /// </summary>
+    /// <param name="activeInd">The active indicator used to filter jokes. The default is "Y".</param>
+    /// <param name="requestingUserName">The username of the user requesting the count. The default is "ANON".</param>
+    /// <returns>The number of joke records that match the filter.</returns>
+    int CountAll(string activeInd = "Y", string requestingUserName = "ANON");
+
+    /// <summary>
     /// Returns the most recently modified jokes, limited to the specified count.
     /// For SQL repositories, results are ordered by <see cref="Joke.ChangeDateTime"/> descending.
     /// For JSON repositories, jokes are ordered by <see cref="Joke.ChangeDateTime"/> descending then limited to <paramref name="count"/> entries.

--- a/src/web/Data/Repositories/JokeJsonRepository.cs
+++ b/src/web/Data/Repositories/JokeJsonRepository.cs
@@ -173,6 +173,17 @@ public class JokeJsonRepository : IJokeRepository
     }
 
     /// <summary>
+    /// Gets the count of jokes contained in the JSON repository.
+    /// </summary>
+    /// <param name="activeInd">The active indicator filter, ignored for the JSON repository.</param>
+    /// <param name="requestingUserName">The username of the caller requesting the count.</param>
+    /// <returns>The number of jokes in the repository.</returns>
+    public int CountAll(string activeInd = "Y", string requestingUserName = "ANON")
+    {
+        return _jokes.Count;
+    }
+
+    /// <summary>
     /// Returns the most recently modified jokes from the JSON repository, ordered by last-modified date descending and limited to <paramref name="count"/> records.
     /// </summary>
     /// <param name="count">The maximum number of jokes to return. The default is 100.</param>

--- a/src/web/Data/Repositories/JokeSQLRepository.cs
+++ b/src/web/Data/Repositories/JokeSQLRepository.cs
@@ -100,6 +100,17 @@ public class JokeSQLRepository(DadABaseDbContext context) : IJokeRepository
     }
 
     /// <summary>
+    /// Gets the count of active jokes in the database.
+    /// </summary>
+    /// <param name="activeInd">The active indicator, typically "Y" or "N".</param>
+    /// <param name="requestingUserName">The username of the user requesting the count.</param>
+    /// <returns>The number of jokes matching the active indicator.</returns>
+    public int CountAll(string activeInd = "Y", string requestingUserName = "ANON")
+    {
+        return _context.Jokes.Count(j => j.ActiveInd == activeInd);
+    }
+
+    /// <summary>
     /// Returns the most recently modified active jokes, ordered by last-modified date descending and limited to <paramref name="count"/> records.
     /// </summary>
     /// <param name="count">The maximum number of jokes to return. The default is 100.</param>

--- a/src/web/Website/Pages/Index.razor
+++ b/src/web/Website/Pages/Index.razor
@@ -7,6 +7,14 @@
 <div class="page-container">
     <MudContainer MaxWidth="MaxWidth.Large">
         <h1>@(isNinetiesTheme ? "Tell me a Joke, Grandpa!" : "Tell me a Joke, Dad!")</h1>
+        @if (jokeCount > 0)
+        {
+            <p class="joke-tagline">
+                @(isNinetiesTheme
+                    ? $"Totally radical! We've got {jokeCount} gnarly jokes in da house! 🕺"
+                    : $"Warning: {jokeCount} groan-worthy dad jokes on tap — side effects may include eye-rolling and uncontrollable chuckling! 😄")
+            </p>
+        }
         @if (jokeLoading)
         {
             <MudProgressCircular Color="Color.Primary" Indeterminate="true" />

--- a/src/web/Website/Pages/Index.razor
+++ b/src/web/Website/Pages/Index.razor
@@ -7,14 +7,6 @@
 <div class="page-container">
     <MudContainer MaxWidth="MaxWidth.Large">
         <h1>@(isNinetiesTheme ? "Tell me a Joke, Grandpa!" : "Tell me a Joke, Dad!")</h1>
-        @if (jokeCount > 0)
-        {
-            <p class="joke-tagline">
-                @(isNinetiesTheme
-                    ? $"Totally radical! We've got {jokeCount} gnarly jokes in da house! 🕺"
-                    : $"Warning: {jokeCount} groan-worthy dad jokes on tap — side effects may include eye-rolling and uncontrollable chuckling! 😄")
-            </p>
-        }
         @if (jokeLoading)
         {
             <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
@@ -38,6 +30,14 @@
                     </Authorized>
                 </AuthorizeView>
             </div>
+            @if (jokeCount > 0)
+            {
+                <p class="joke-tagline">
+                    @(isNinetiesTheme
+                        ? $"Totally radical! We've got {jokeCount} gnarly jokes in da house! 🕺"
+                        : $"Warning: {jokeCount} groan-worthy dad jokes on tap — side effects may include eye-rolling and uncontrollable chuckling! 😄")
+                </p>
+            }
             @if (isNinetiesTheme)
             {
                 <div style="text-align: center; margin-top: 20px;">

--- a/src/web/Website/Pages/Index.razor.cs
+++ b/src/web/Website/Pages/Index.razor.cs
@@ -25,6 +25,7 @@ public partial class Index : ComponentBase, IDisposable
     private Joke myJoke = new();
     private readonly bool addDelay = false;
     private bool jokeLoading = false;
+    private int jokeCount = 0;
 
     // Store the last 10 jokes
     private List<Joke> jokeHistory = new();
@@ -58,6 +59,7 @@ public partial class Index : ComponentBase, IDisposable
             await JsInterop.InvokeVoidAsync("syncHeaderTitle");
             var theme = await JsInterop.InvokeAsync<string>("localStorage.getItem", "theme-mode");
             isNinetiesTheme = theme == "nineties";
+            jokeCount = JokeRepository.ListAll().Count();
             await ExecuteRandom();
             StateHasChanged();
         }

--- a/src/web/Website/Pages/Index.razor.cs
+++ b/src/web/Website/Pages/Index.razor.cs
@@ -59,7 +59,7 @@ public partial class Index : ComponentBase, IDisposable
             await JsInterop.InvokeVoidAsync("syncHeaderTitle");
             var theme = await JsInterop.InvokeAsync<string>("localStorage.getItem", "theme-mode");
             isNinetiesTheme = theme == "nineties";
-            jokeCount = JokeRepository.ListAll().Count();
+            jokeCount = JokeRepository.CountAll();
             await ExecuteRandom();
             StateHasChanged();
         }

--- a/src/web/Website/Pages/Index.razor.css
+++ b/src/web/Website/Pages/Index.razor.css
@@ -48,6 +48,19 @@ body[data-bs-theme='dark'] .image-note,
     }
 }
 
+.joke-tagline {
+    font-size: 1.05em;
+    font-style: italic;
+    color: var(--text-secondary-light);
+    margin-bottom: 1.5rem;
+    opacity: 0.85;
+}
+
+body[data-bs-theme='dark'] .joke-tagline,
+.theme-dark .joke-tagline {
+    color: var(--text-secondary-dark);
+}
+
 .joke-container {
     animation: slideIn 0.5s ease-out;
 }

--- a/src/web/Website/Pages/Index.razor.css
+++ b/src/web/Website/Pages/Index.razor.css
@@ -52,6 +52,7 @@ body[data-bs-theme='dark'] .image-note,
     font-size: 1.05em;
     font-style: italic;
     color: var(--text-secondary-light);
+    margin-top: 0.75rem;
     margin-bottom: 1.5rem;
     opacity: 0.85;
 }

--- a/src/web/Website/Shared/ThemeSwitcher.razor.cs
+++ b/src/web/Website/Shared/ThemeSwitcher.razor.cs
@@ -37,20 +37,32 @@ public partial class ThemeSwitcher : ComponentBase
         if (firstRender && !_initialized)
         {
             _initialized = true;
-            var mode = await JS.InvokeAsync<string>("localStorage.getItem", ThemeKey);
-            if (!string.IsNullOrEmpty(mode))
+            try
             {
-                await ApplyTheme(mode);
+                var mode = await JS.InvokeAsync<string>("localStorage.getItem", ThemeKey);
+                if (!string.IsNullOrEmpty(mode))
+                {
+                    await ApplyTheme(mode);
+                }
+                else
+                {
+                    await ApplyTheme("system");
+                }
             }
-            else
+            catch (JSDisconnectedException)
             {
-                await ApplyTheme("system");
             }
         }
         else if (_pendingTheme is not null)
         {
-            await ApplyTheme(_pendingTheme);
-            _pendingTheme = null;
+            try
+            {
+                await ApplyTheme(_pendingTheme);
+                _pendingTheme = null;
+            }
+            catch (JSDisconnectedException)
+            {
+            }
         }
     }
 
@@ -62,9 +74,15 @@ public partial class ThemeSwitcher : ComponentBase
     private async Task SetTheme(ThemeMode mode)
     {
         var modeStr = mode.ToString().ToLower();
-        await JS.InvokeVoidAsync("localStorage.setItem", ThemeKey, modeStr);
-        _pendingTheme = modeStr;
-        StateHasChanged();
+        try
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", ThemeKey, modeStr);
+            _pendingTheme = modeStr;
+            StateHasChanged();
+        }
+        catch (JSDisconnectedException)
+        {
+        }
     }
 
     /// <summary>
@@ -75,24 +93,30 @@ public partial class ThemeSwitcher : ComponentBase
     private async Task ApplyTheme(string mode)
     {
         // Remove all theme classes.
-        await JS.InvokeVoidAsync("eval", "document.body.classList.remove('theme-light','theme-dark','theme-nineties','theme-system');");
-        if (mode == "light")
+        try
         {
-            await JS.InvokeVoidAsync("eval", "document.body.classList.add('theme-light'); document.body.setAttribute('data-bs-theme','light');");
-        }
-        else if (mode == "dark")
-        {
-            await JS.InvokeVoidAsync("eval", "document.body.classList.add('theme-dark'); document.body.setAttribute('data-bs-theme','dark');");
-        }
-        else if (mode == "nineties")
-        {
-            await JS.InvokeVoidAsync("eval", "document.body.classList.add('theme-nineties'); document.body.setAttribute('data-bs-theme','light');");
-        }
-        else
-        {
-            await JS.InvokeVoidAsync("eval", "document.body.classList.add('theme-system'); document.body.removeAttribute('data-bs-theme');");
-        }
+            await JS.InvokeVoidAsync("eval", "document.body.classList.remove('theme-light','theme-dark','theme-nineties','theme-system');");
+            if (mode == "light")
+            {
+                await JS.InvokeVoidAsync("eval", "document.body.classList.add('theme-light'); document.body.setAttribute('data-bs-theme','light');");
+            }
+            else if (mode == "dark")
+            {
+                await JS.InvokeVoidAsync("eval", "document.body.classList.add('theme-dark'); document.body.setAttribute('data-bs-theme','dark');");
+            }
+            else if (mode == "nineties")
+            {
+                await JS.InvokeVoidAsync("eval", "document.body.classList.add('theme-nineties'); document.body.setAttribute('data-bs-theme','light');");
+            }
+            else
+            {
+                await JS.InvokeVoidAsync("eval", "document.body.classList.add('theme-system'); document.body.removeAttribute('data-bs-theme');");
+            }
 
-        ThemeService.NotifyThemeChanged();
+            ThemeService.NotifyThemeChanged();
+        }
+        catch (JSDisconnectedException)
+        {
+        }
     }
 }

--- a/src/web/Website/applicationSettings.json
+++ b/src/web/Website/applicationSettings.json
@@ -6,7 +6,8 @@
     "EnvironmentName": "Development",
     "DataSource": "JSON",
     "EnableSwagger": true,
-
+    "DetailedErrors": true,
+    
     "NOTSET-USE-JSON-DefaultConnection": "",
     "DefaultConnection": "",
     "AdminUserList": "",


### PR DESCRIPTION
This pull request enhances the home page by displaying a dynamic tagline that shows the total number of available jokes, with messaging tailored to the current theme. It also introduces styling for the new tagline and updates the logic to fetch and display the joke count.

**User Interface Improvements:**

* Added a tagline under the page title in `Index.razor` that displays the total number of jokes, with different messages depending on whether the "nineties" theme is active.
* Introduced a new CSS class `.joke-tagline` in `Index.razor.css` to style the tagline, including theme-specific color adjustments for both light and dark modes.

**Logic and Data Updates:**

* Added a `jokeCount` field to the `Index` component and updated the logic in `OnAfterRenderAsync` to fetch the total number of jokes from the `JokeRepository` and store it in `jokeCount`. [[1]](diffhunk://#diff-73238cf04861aac0f6806c535284bc29252e92495c02762599721fccf9e82266R28) [[2]](diffhunk://#diff-73238cf04861aac0f6806c535284bc29252e92495c02762599721fccf9e82266R62)