### PR TITLE
Joke rating system

### DIFF
--- a/.github/CreateGitHubSecrets.md
+++ b/.github/CreateGitHubSecrets.md
@@ -4,13 +4,26 @@ The GitHub workflows in this project require several secrets set at the reposito
 
 ---
 
-## Azure Resource Creation Credentials
+## Azure Credentials
 
-You need to set up the Azure Credentials secret in the GitHub Secrets at the Repository level before you do anything else.
+Before you begin, you will need to set up the Azure Credentials secrets in the GitHub Secrets at the Repository level (or the environment level).  These secrets and credentials will allow the GitHub Actions to deploy into Azure.
 
-See [https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-github-actions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-github-actions) for more info.
+See the reference links below for more info on how to create the service principal and set up the Federated Credentials.
 
-To create these secrets, customize and run this command:
+> Note: this service principal must have **Contributor** rights to your subscription (or resource group) to deploy the resources. If you want to assign roles in the Bicep, it will also need the **User Access Administrator** role.  (Alternatively, you can put the service principal in the **Owner** role also, but that doesn't follow least privilege.)
+
+### Update on Federated Credentials
+Prior to July 2026, when you set up a federated identity credential in an App Registration to use in a GH Action, you only needed to supply the owner name and repo name and (environment/branch). All repositories created after **July 15, 2026** will now have to also supply the **IMMUTABLE** values (which are numeric values for the org/user and the repository).
+
+To find those values, run these commands and they will return the numeric **IMMUTABLE** values:
+```bash
+gh api user --jq .id
+gh api repos/<yourOrg>/<yourRepo> --jq .id
+```
+
+> NOTE: the first command is for a *USER* (i.e. lluppesms), NOT for an *ORG*…  I'm not sure if there is a different command for that.
+
+Once the credentials are set up, customize and run this command to create these secrets:
 
 ``` bash
 gh auth login
@@ -52,6 +65,13 @@ gh variable set OPENAI_IMAGE_DEPLOYMENTNAME -b 'gpt-image-1.5'
 
 gh variable set SQL_SERVER_NAME_PREFIX -b 'your-dadabase-server'
 gh variable set SQL_DATABASE_NAME -b 'DadABase'
+gh variable set SQLADMIN_LOGIN_USERID -b 'youruser@yourdomain.com'
+gh variable set SQLADMIN_LOGIN_USERSID -b 'yoursid'
+gh variable set SQLADMIN_LOGIN_TENANTID -b 'yourtennant'
+
+gh variable set CREATE_USER_ASSIGNED_IDENTITY -b 'false'
+gh variable set ADMIN_USER_LIST -b 'user1@domain.com,user2@domain.com'
+
 gh variable set EXISTING_SERVICEPLAN_NAME -b ''
 gh variable set EXISTING_SERVICEPLAN_RESOURCE_GROUP_NAME -b ''
 gh variable set EXISTING_SQLSERVER_NAME -b ''
@@ -59,13 +79,6 @@ gh variable set EXISTING_SQLDATABASE_NAME -b ''
 gh variable set EXISTING_SQLSERVER_RESOURCE_GROUP_NAME -b ''
 gh variable set EXISTING_LOGANALYTICSWORKSPACE -b ''
 gh variable set EXISTING_LOG_ANALYTICS_WORKSPACE_RESOURCE_GROUP_NAME -b ''
-gh variable set CREATE_USER_ASSIGNED_IDENTITY -b 'false'
-
-gh variable set SQLADMIN_LOGIN_USERID -b 'youruser@yourdomain.com'
-gh variable set SQLADMIN_LOGIN_USERSID -b 'yoursid'
-gh variable set SQLADMIN_LOGIN_TENANTID -b 'yourtennant'
-
-gh variable set ADMIN_USER_LIST -b 'user1@domain.com,user2@domain.com'
 ```
 
 Leave the `EXISTING_*` variables blank to let Bicep create new resources. To reuse SQL resources, set both `EXISTING_SQLSERVER_NAME` and `EXISTING_SQLDATABASE_NAME`. To reuse an existing Log Analytics Workspace, set `EXISTING_LOGANALYTICSWORKSPACE` to its name and optionally `EXISTING_LOG_ANALYTICS_WORKSPACE_RESOURCE_GROUP_NAME` if it is in a different resource group. Set `CREATE_USER_ASSIGNED_IDENTITY` to `'true'` to provision a separate user-assigned managed identity; leave it `'false'` (default) to use each resource's own system-assigned identity.
@@ -74,6 +87,9 @@ Leave the `EXISTING_*` variables blank to let Bicep create new resources. To reu
 
 ## References
 
-[Deploying ARM Templates with GitHub Actions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-github-actions)
-
-[GitHub Secrets CLI](https://cli.github.com/manual/gh_secret_set)
+- [Deploying ARM Templates with GitHub Actions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-github-actions)
+- [Manage Federated Identity Credential in Entra Id](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp) (MS Learn)
+- [Immutable subject claims for GitHub Actions OIDC tokens](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/) (GitHub Changelog Announcement - April 2026)
+- [Migrate GitHub Actions federated credentials to immutable subjects](https://learn.microsoft.com/en-us/entra/workload-id/workload-identities-github-immutable-subjects) (MS Learn)
+- [GitHub Secrets CLI](https://cli.github.com/manual/gh_secret_set)
+- [GitHub Variables CLI](https://cli.github.com/manual/gh_variable_set)

--- a/.github/actions/login-action/action.yml
+++ b/.github/actions/login-action/action.yml
@@ -35,7 +35,7 @@ runs:
 
     - name: Login to Azure using OIDC
       if: ${{ steps.auth-check.outputs.auth-method == 'oidc' }}
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
@@ -43,7 +43,7 @@ runs:
 
     - name: Login to Azure using Secret
       if: ${{ steps.auth-check.outputs.auth-method == 'client-secret' }}
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         creds: '{"clientId":"${{ inputs.client-id }}","clientSecret":"${{ inputs.client-secret }}","tenantId":"${{ inputs.tenant-id }}","subscriptionId":"${{ inputs.subscription-id }}"}'
 

--- a/.github/workflows-readme.md
+++ b/.github/workflows-readme.md
@@ -5,9 +5,9 @@ author: DadABase maintainers
 ms.date: 2026-05-14
 ms.topic: how-to
 keywords:
-	- github actions
-	- azure
-	- dadabase
+- github actions
+- azure
+- dadabase
 estimated_reading_time: 6
 ---
 
@@ -41,11 +41,9 @@ When you first create the application, you will have to deploy the application u
 
 Before you begin, you will need to set up the Azure Credentials secrets in the GitHub Secrets at the Repository level (or the environment level).  These secrets and credentials will allow the GitHub Actions to deploy into Azure.
 
-See [https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-github-actions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-github-actions) for more info on how to create the service principal and set up these credentials.
+See the **[CreateGitHubSecrets.md](./CreateGitHubSecrets.md)** file for info on how to create the a service principal and set up the Federated Credentials.
 
-> Note: this service principal must have contributor rights to your subscription (or resource group) to deploy the resources.
-
-You can customize and run the following commands, or you can set these secrets up manually by going to the Settings -> Secrets -> Actions -> Secrets.
+Once the credentials are set up, you can customize and run the following commands, or you can set these secrets up manually by going to the Settings -> Secrets -> Actions -> Secrets.
 
 You can set these up at the Repository Level...
 
@@ -97,7 +95,7 @@ Once these rights are in place, before the application can run successfully, the
 
 ## Bicep Configuration Values
 
-There are many values used by the Bicep templates to configure the resource names that are deployed. Make sure the App_Name variable is unique to your deployment. It will be used as the basis for the application name and for all the other Azure resources, some of which must be globally unique.
+There are other values used by the Bicep templates to configure the resource names that are deployed. Make sure the App_Name variable is unique to your deployment. It will be used as the basis for the application name and for all the other Azure resources, some of which must be globally unique.
 
 See the **[CreateGitHubSecrets.md](./CreateGitHubSecrets.md)** file for the full list of commands to create these variables and secrets.
 
@@ -106,7 +104,12 @@ See the **[CreateGitHubSecrets.md](./CreateGitHubSecrets.md)** file for the full
 ## References
 
 - [Deploying ARM Templates with GitHub Actions](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-github-actions)
+- [Manage Federated Identity Credential in Entra Id](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp) (MS Learn)
+- [Immutable subject claims for GitHub Actions OIDC tokens](https://github.blog/changelog/2026-04-23-immutable-subject-claims-for-github-actions-oidc-tokens/) (GitHub Changelog Announcement - April 2026)
+- [Migrate GitHub Actions federated credentials to immutable subjects](https://learn.microsoft.com/en-us/entra/workload-id/workload-identities-github-immutable-subjects) (MS Learn)
+- [GitHub Secrets CLI](https://cli.github.com/manual/gh_secret_set)
+- [GitHub Variables CLI](https://cli.github.com/manual/gh_variable_set)
 
 ---
 
-[Home Page](../README.md)
+[Return to Home Page](../README.md)

--- a/.github/workflows/azure-dev.yml
+++ b/.github/workflows/azure-dev.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in with Azure
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           creds: '{"clientId":"${{ secrets.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ secrets.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.AZURE_TENANT_ID }}"}'
   

--- a/.github/workflows/template-containerapp-deploy.yml
+++ b/.github/workflows/template-containerapp-deploy.yml
@@ -39,7 +39,7 @@ jobs:
       continue-on-error: true
 
     - name: Login to Azure using OIDC
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/template-run-sql.yml
+++ b/.github/workflows/template-run-sql.yml
@@ -106,7 +106,7 @@ jobs:
           Get-ChildItem -Path "${{ inputs.sqlFolderName }}" -Recurse -ErrorAction SilentlyContinue
 
       # - name: Azure Login
-      #   uses: azure/login@v2
+      #   uses: azure/login@v3
       #   with:
       #     creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Azure Login (Reusable Action)

--- a/.github/workflows/template-webapp-deploy.yml
+++ b/.github/workflows/template-webapp-deploy.yml
@@ -42,7 +42,7 @@ jobs:
       continue-on-error: true
   
     - name: Login to Azure using OIDC
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ secrets.AZURE_CLIENT_ID }}
         tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/Docs/Joke-Rating-Implementation-Plan.md
+++ b/Docs/Joke-Rating-Implementation-Plan.md
@@ -1,0 +1,174 @@
+# DadABase Joke Rating Implementation Plan
+
+Date: 2026-07-06
+Status: Proposed for review
+
+## Goal
+Enable users to submit a 1-5 star rating for each joke, whether they are logged in or anonymous, with one rating per joke per user identity key.
+
+## Key Requirement Clarification
+A uniqueness rule must prevent duplicate ratings from the same user for the same joke, while still allowing multiple anonymous users to rate the same joke.
+
+To satisfy this:
+- Logged-in users will use their authenticated user key.
+- Anonymous users will use an IP-based key (derived from request IP), so different anonymous users can each submit their own rating.
+
+## Identity Key Strategy
+Define a single RatingUserKey value used by uniqueness checks and upsert logic.
+
+- Logged-in request:
+  - RatingUserKey = authenticated user identifier (stable claim or identity name).
+- Anonymous request:
+  - RatingUserKey = derived from client IP address.
+
+Recommended anonymous key format:
+- Raw source: normalized client IP from trusted forwarding headers or remote endpoint.
+- Stored key: hash of IP with app-level salt (not plain-text IP).
+- Example concept: ANON_IP_SHA256(<ip> + <salt>)
+
+Why hash the IP:
+- Reduces storage of plain PII.
+- Still provides deterministic uniqueness for anonymous requests.
+
+## Database Changes
+1. Add identity key column to rating table.
+- Add column on Dad.JokeRating:
+  - RatingUserKey nvarchar(255) not null
+
+2. Add uniqueness constraint.
+- Unique index on:
+  - JokeId
+  - RatingUserKey
+
+This enforces one rating per joke per effective user key.
+
+3. Keep existing rating validation.
+- UserRating must remain between 1 and 5.
+
+4. Add or update stored procedure for rating upsert.
+- Procedure behavior:
+  - Validate joke exists.
+  - Validate star value range.
+  - Upsert by JokeId + RatingUserKey.
+  - Recompute Joke.Rating and Joke.VoteCount from Dad.JokeRating for that joke.
+  - Return updated summary and whether insert or update occurred.
+
+## Application Changes
+### 1. Repository Contract
+Update repository interface with explicit rating operations:
+- SubmitOrUpdateRating(jokeId, userRating, ratingUserKey)
+- GetUserRatingForJoke(jokeId, ratingUserKey)
+- GetRatingSummaryForJoke(jokeId)
+
+### 2. SQL Repository
+Implement methods in the SQL repository using stored procedure execution.
+
+### 3. JSON Repository Fallback
+Mirror rating behavior in JSON mode so local and SQL modes stay functionally aligned.
+
+### 4. Identity Resolution Service
+Add a dedicated helper/service that builds RatingUserKey consistently across API and Blazor component paths.
+
+Rules:
+- Logged-in: use stable authenticated identifier.
+- Anonymous: resolve client IP, normalize, hash with salt, prefix with ANON_IP_.
+
+Important implementation detail:
+- Respect forwarded headers only when proxy trust is configured.
+- Avoid using untrusted client-provided headers directly.
+
+### 5. API Endpoints
+Add API endpoint(s) for rating submit/update and summary fetch:
+- POST rating (AllowAnonymous)
+- GET user + aggregate rating context
+
+Response should include:
+- JokeId
+- UserRating
+- AverageRating
+- VoteCount
+- WasUpdate
+
+### 6. UI Integration
+Re-enable rating UI in joke display component and wire to new repository/API methods.
+
+UX requirements:
+- User can select 1-5 stars.
+- Existing rating is shown for current user context.
+- Updating a prior rating is supported.
+- Aggregate average and vote count refresh after submit.
+
+## Testing Tasks
+### Database
+- Unique index blocks duplicate row for same JokeId + RatingUserKey.
+- Different anonymous IP keys can rate the same joke independently.
+- Upsert procedure handles insert and update paths correctly.
+
+### Repository
+- Submit first rating creates row.
+- Submit second rating same key updates row, does not create duplicate.
+- Invalid ratings are rejected.
+- Average and vote count are correct after mixed updates.
+
+### API
+- Anonymous rating with IP-derived key succeeds.
+- Logged-in rating succeeds.
+- Two anonymous requests from different IPs both succeed on same joke.
+- Same anonymous IP updates prior rating on same joke.
+
+### UI/Component
+- Star control renders and submits.
+- Existing user rating loads and displays.
+- Aggregate values update after submission.
+
+## Security, Privacy, and Operations Considerations
+1. IP as anonymous key tradeoffs.
+- Pros: straightforward uniqueness for anonymous users.
+- Cons: shared NAT/proxy can represent multiple users behind one IP.
+
+2. Mitigation options (recommended roadmap).
+- Phase 1: IP-derived hashed key (fastest to deliver).
+- Phase 2: combine IP hash + long-lived anonymous browser token cookie for better per-user distinction.
+
+3. Forwarded header trust.
+- Configure known proxies/networks before honoring X-Forwarded-For.
+- Fall back safely to remote IP when forwarding is unavailable.
+
+4. Data retention.
+- Document retention policy for rating records and hashed anonymous keys.
+
+## Implementation Task Breakdown
+1. SQL schema update for RatingUserKey and unique index.
+2. SQL stored procedure for rating upsert and aggregate recompute.
+3. Repository interface update.
+4. SQL repository implementation.
+5. JSON repository parity implementation.
+6. Rating user key resolver (auth and anonymous IP handling).
+7. API endpoints for submit and summary.
+8. Joke display component rating UI activation and wiring.
+9. Unit and integration tests.
+10. Documentation updates and deployment notes.
+
+## Acceptance Criteria
+- A logged-in user can rate any joke and update their own rating.
+- Anonymous users can rate any joke.
+- Different anonymous users are not blocked by uniqueness (IP-derived keys differ).
+- Same user key cannot create duplicate rows for the same joke.
+- Joke.Rating and Joke.VoteCount remain accurate after inserts and updates.
+- Feature works in both SQL and JSON data modes.
+
+## Open Questions for Final Approval
+1. Should anonymous key be IP hash only, or IP hash plus persistent anonymous cookie in phase 1?
+2. Which authenticated claim should be canonical for logged-in user key in this app?
+3. Is rating change history needed, or only current effective rating per user?
+4. Should anonymous ratings be rate-limited per IP to reduce abuse?
+
+## Recommended First Implementation Slice
+To reduce delivery risk, implement in this order:
+1. Database schema + upsert procedure.
+2. Repository methods.
+3. API endpoint.
+4. UI component wiring.
+5. Tests and hardening.
+
+This sequence gives early validation at the data boundary before UI work.

--- a/Docs/Joke-Rating-Implementation-Tasks.md
+++ b/Docs/Joke-Rating-Implementation-Tasks.md
@@ -1,0 +1,289 @@
+# Joke Rating Feature – Implementation Task Queue
+
+**Branch:** `feature/joke-rating-system`  
+**Status:** Queued for implementation  
+**Reference:** See [Joke-Rating-Implementation-Plan.md](Joke-Rating-Implementation-Plan.md)
+
+---
+
+## Phase 1: Database & Stored Procedure (Foundation)
+
+### Task 1.1: Add RatingUserKey Column to JokeRating Table
+- **File(s):** `src/sql.database/Dad/Tables/JokeRating.sql`
+- **Change:** Add column `RatingUserKey nvarchar(255) not null`
+- **Constraint:** Make CreateUserName nullable or deprecate if RatingUserKey becomes the canonical key
+- **Acceptance:** Column present, default constraint if needed, can insert test rows with new column
+- **Effort:** 1 dev-hour
+
+### Task 1.2: Add Unique Constraint (JokeId + RatingUserKey)
+- **File(s):** `src/sql.database/Dad/Tables/JokeRating.sql`
+- **Change:** Add unique index/constraint on (JokeId, RatingUserKey)
+- **Acceptance:** Constraint in place; attempts to insert duplicate fail with integrity error
+- **Effort:** 0.5 dev-hour
+
+### Task 1.3: Create/Update usp_Joke_Rate Stored Procedure
+- **File(s):** Create `src/sql.database/Dad/Stored Procedures/usp_Joke_Rate.sql`
+- **Parameters:**
+  - @jokeId int
+  - @userRating int (validate 1-5)
+  - @ratingUserKey nvarchar(255)
+- **Logic:**
+  - Validate JokeId exists
+  - Validate UserRating in [1,5]
+  - Upsert: if (JokeId, RatingUserKey) exists, update; else insert
+  - After upsert, recompute Joke.Rating and Joke.VoteCount from JokeRating aggregates
+  - Return: JokeId, UserRating, AverageRating, VoteCount, @WasInsert bit
+- **Acceptance:** Procedure callable, idempotent, aggregates stay in sync
+- **Effort:** 3 dev-hours
+
+### Task 1.4: Create Migration Patch Script
+- **File(s):** Create `src/sql.database/Patch/Patch-20260706-add-rating-user-key.sql`
+- **Scope:** For existing environments without RatingUserKey column
+- **Logic:** Add column, create constraint, backfill existing rows with legacy CreateUserName or ANON_LEGACY
+- **Acceptance:** Script runs idempotently on existing DB, no errors
+- **Effort:** 1.5 dev-hours
+
+---
+
+## Phase 2: Repository & Data Access Layer
+
+### Task 2.1: Update IJokeRepository Interface
+- **File(s):** `src/web/Data/Repositories/IJokeRepository.cs`
+- **Methods to add:**
+  - `Task<(bool Success, int UserRating, decimal AverageRating, int VoteCount, bool WasInsert)> SubmitOrUpdateRating(int jokeId, int userRating, string ratingUserKey, string requestingUserName);`
+  - `Task<int?> GetUserRatingForJoke(int jokeId, string ratingUserKey);`
+  - `Task<(decimal AverageRating, int VoteCount)> GetRatingSummaryForJoke(int jokeId);`
+- **Acceptance:** Interface compiles, methods are async, clear return types
+- **Effort:** 1 dev-hour
+
+### Task 2.2: Implement Methods in JokeSQLRepository
+- **File(s):** `src/web/Data/Repositories/JokeSQLRepository.cs`
+- **Implementation:**
+  - Call stored procedure usp_Joke_Rate via _context.Database.ExecuteSqlInterpolated
+  - Return result using SqlDataReader or EF parameter mapping
+  - Handle transaction semantics if needed
+- **Acceptance:** Unit tests pass for insert, update, duplicate-reject paths
+- **Effort:** 3 dev-hours
+
+### Task 2.3: Implement Fallback Methods in JokeJsonRepository
+- **File(s):** `src/web/Data/Repositories/JokeJsonRepository.cs`
+- **Implementation:**
+  - In-memory dictionary: Dictionary<(int JokeId, string RatingUserKey), int UserRating>
+  - Upsert logic mirrors SQL behavior
+  - Aggregate computation from dictionary entries
+  - Persist aggregates back to Joke objects
+- **Acceptance:** Behavior parity with SQL; single anonymous key blocks duplicate, different keys don't
+- **Effort:** 2.5 dev-hours
+
+---
+
+## Phase 3: Application Services
+
+### Task 3.1: Create RatingUserKeyResolver Service
+- **File(s):** Create `src/web/Website/Services/RatingUserKeyResolver.cs`
+- **Logic:**
+  - Input: HttpContext
+  - If authenticated: extract stable claim/identity name
+  - If anonymous: resolve client IP, hash with salt, return ANON_IP_<hash>
+  - Respect X-Forwarded-For only if configured proxy list
+  - Fall back safely to RemoteIpAddress when forwarding unavailable
+- **Configuration:** Add appsettings option for proxy trust list and hash salt
+- **Acceptance:** Unit tests for auth and anon paths, IP normalization, safe fallback
+- **Effort:** 2 dev-hours
+
+### Task 3.2: Register RatingUserKeyResolver in DI
+- **File(s):** `src/web/Website/Program.cs`
+- **Change:** Add `builder.Services.AddScoped<RatingUserKeyResolver>();`
+- **Acceptance:** Service resolves at runtime without errors
+- **Effort:** 0.5 dev-hour
+
+---
+
+## Phase 4: API Endpoints
+
+### Task 4.1: Add Rating Submit/Update Endpoint
+- **File(s):** `src/web/Website/API/JokeController.cs`
+- **Endpoint:** POST `/api/joke/rate`
+- **Request body:**
+  ```json
+  { "jokeId": 5, "userRating": 4 }
+  ```
+- **Response:**
+  ```json
+  {
+    "jokeId": 5,
+    "userRating": 4,
+    "averageRating": 3.8,
+    "voteCount": 42,
+    "wasInsert": false
+  }
+  ```
+- **Attributes:** [AllowAnonymous], [ApiKey]
+- **Logic:**
+  - Validate jokeId exists
+  - Resolve rating user key
+  - Call repository SubmitOrUpdateRating
+  - Return payload
+- **Acceptance:** Endpoint callable, returns correct structure, handles errors gracefully
+- **Effort:** 2 dev-hours
+
+### Task 4.2: Add Rating Summary Endpoint
+- **File(s):** `src/web/Website/API/JokeController.cs`
+- **Endpoint:** GET `/api/joke/{id}/rating/summary`
+- **Response:**
+  ```json
+  { "jokeId": 5, "averageRating": 3.8, "voteCount": 42 }
+  ```
+- **Attributes:** [AllowAnonymous]
+- **Logic:** Call repository GetRatingSummaryForJoke
+- **Acceptance:** Endpoint returns current aggregates
+- **Effort:** 1 dev-hour
+
+### Task 4.3: Add User Rating Endpoint (Optional—for UI context)
+- **File(s):** `src/web/Website/API/JokeController.cs`
+- **Endpoint:** GET `/api/joke/{id}/rating/current`
+- **Response:**
+  ```json
+  { "jokeId": 5, "userRating": 4 }
+  ```
+- **Logic:** Resolve rating user key, fetch current user rating
+- **Acceptance:** Returns user's rating or null if not rated
+- **Effort:** 1 dev-hour
+
+---
+
+## Phase 5: UI Component Integration
+
+### Task 5.1: Re-enable Rating Markup in JokeDisplayComponent.razor
+- **File(s):** `src/web/Website/Components/JokeDisplayComponent.razor`
+- **Change:** Uncomment the rating block (currently commented out around line 38)
+- **Acceptance:** Markup renders without errors
+- **Effort:** 0.5 dev-hour
+
+### Task 5.2: Complete Rating Logic in JokeDisplayComponent.razor.cs
+- **File(s):** `src/web/Website/Components/JokeDisplayComponent.razor.cs`
+- **Logic:**
+  - Inject IJokeRepository
+  - On init: load current user rating and aggregate summary
+  - OnSubmitRating: call repository, update display, handle errors
+  - Show success snackbar or error toast
+- **Acceptance:** Rating UI loads, submit works, display updates
+- **Effort:** 3 dev-hours
+
+### Task 5.3: Wire Component to API
+- **Consideration:** If using API instead of direct repository, add HttpClient calls
+- **Acceptance:** Component integrates with API endpoints
+- **Effort:** 1 dev-hour (if API-first approach)
+
+---
+
+## Phase 6: Testing
+
+### Task 6.1: Unit Tests – Repository (SQL Path)
+- **File(s):** Create/update `src/web/Tests/RepositoryTests/JokeRating_Repository_Tests.cs`
+- **Scenarios:**
+  - First rating insert
+  - Update existing rating same key
+  - Reject duplicate key (unique constraint)
+  - Validate rating range (1-5)
+  - Aggregate calculation (avg and vote count)
+  - Different keys can rate same joke
+- **Acceptance:** All scenarios covered, tests pass
+- **Effort:** 3 dev-hours
+
+### Task 6.2: Unit Tests – RatingUserKeyResolver
+- **File(s):** Create `src/web/Tests/Services/RatingUserKeyResolver_Tests.cs`
+- **Scenarios:**
+  - Authenticated user returns consistent key
+  - Anonymous IP-derived key format correct
+  - Different IPs return different keys
+  - IP hashing deterministic
+  - Proxy forwarding respected when configured
+  - Safe fallback on missing forwarding
+- **Acceptance:** All scenarios covered, tests pass
+- **Effort:** 2 dev-hours
+
+### Task 6.3: Integration Tests – API Endpoints
+- **File(s):** Create `src/web/Tests/API/JokeRating_API_Tests.cs`
+- **Scenarios:**
+  - POST rating succeeds for anonymous and authenticated
+  - Two anonymous IPs both succeed on same joke
+  - Same user key update overwrites prior rating
+  - GET summary reflects aggregates
+  - Validation errors return 400/422
+- **Acceptance:** Integration test suite runs, all pass
+- **Effort:** 3 dev-hours
+
+### Task 6.4: Playwright UI Tests (Optional)
+- **File(s):** Create `playwright/ui-tests/joke-rating.spec.ts`
+- **Scenarios:**
+  - User can click stars and submit rating
+  - Rating persists on reload (if applicable)
+  - Aggregate updates after submit
+  - Error feedback displays
+- **Acceptance:** Playwright tests execute, basic UI flow validates
+- **Effort:** 2 dev-hours
+
+---
+
+## Phase 7: Documentation & Hardening
+
+### Task 7.1: Update README / Documentation
+- **File(s):** Update `Docs/`, README
+- **Content:**
+  - Feature overview
+  - Configuration (proxy trust, salt)
+  - Known limitations (NAT behind shared proxy)
+  - Deployment notes
+- **Acceptance:** Clear docs for operators and future maintainers
+- **Effort:** 1 dev-hour
+
+### Task 7.2: Code Review & Refinement
+- **Review focus:**
+  - Security: IP hashing, forwarding header validation
+  - Performance: aggregate recomputation efficiency
+  - Concurrency: race conditions on upsert
+  - Error handling: edge cases (missing joke, invalid rating)
+- **Acceptance:** Code review approved, no blocking issues
+- **Effort:** 2 dev-hours
+
+---
+
+## Summary
+
+| Phase | Task Count | Est. Effort | Notes |
+|-------|------------|-------------|-------|
+| 1: DB | 4 | 6.5 hrs | Foundation; unblock all layers |
+| 2: Repository | 3 | 8.5 hrs | SQL + JSON fallback for feature parity |
+| 3: Services | 2 | 2.5 hrs | Identity resolution, lightweight DI |
+| 4: API | 3 | 4 hrs | RESTful endpoints, clear contracts |
+| 5: UI | 3 | 4.5 hrs | Component wiring, UX integration |
+| 6: Testing | 4 | 10 hrs | Unit, integration, optional E2E |
+| 7: Hardening | 2 | 3 hrs | Docs, review, deployment readiness |
+| **Total** | **21** | **~39 hours** | |
+
+---
+
+## Recommended Execution Order
+
+1. **Database first** (Tasks 1.1 – 1.4): Unblocks all downstream work.
+2. **Repository layer** (Tasks 2.1 – 2.3): Implement data access before UI.
+3. **Services & API** (Tasks 3.1 – 4.3): Identity + endpoints ready for UI.
+4. **UI integration** (Tasks 5.1 – 5.3): Wire components once API stable.
+5. **Testing in parallel** (Tasks 6.1 – 6.4): Begin early, expand as code settles.
+6. **Hardening** (Tasks 7.1 – 7.2): Final review before PR.
+
+---
+
+## Success Criteria
+
+- [ ] Database schema updated and tested.
+- [ ] Stored procedure upserts correctly and recomputes aggregates.
+- [ ] Repository methods pass unit tests for both SQL and JSON modes.
+- [ ] API endpoints are callable and return correct payloads.
+- [ ] UI component loads and submits ratings.
+- [ ] Different anonymous users (different IPs) can both rate the same joke.
+- [ ] Same user key cannot create duplicate ratings for the same joke.
+- [ ] Integration tests pass.
+- [ ] Code review approved.
+- [ ] Documentation updated.

--- a/src/sql.database/Dad/Stored Procedures/usp_Joke_Rate.sql
+++ b/src/sql.database/Dad/Stored Procedures/usp_Joke_Rate.sql
@@ -1,0 +1,112 @@
+-- =============================================
+-- Stored Procedure: usp_Joke_Rate
+-- Description: Upserts a joke rating for a given user key and recomputes
+--              the aggregate Rating and VoteCount on the parent Joke row.
+--              One rating per (JokeId, RatingUserKey) is enforced both by
+--              this procedure and by the unique index on JokeRating.
+-- Parameters:
+--   @jokeId        - The joke to rate.
+--   @userRating    - Star value 1–5.
+--   @ratingUserKey - Opaque user identity:
+--                    authenticated → identity claim value
+--                    anonymous     → "ANON_IP_<SHA256 hash>"
+--   @userName      - Display name stored in CreateUserName / UpdateUserName.
+-- Returns (single-row result set):
+--   JokeId, UserRating, AverageRating, VoteCount, WasInsert
+-- =============================================
+CREATE OR ALTER PROCEDURE [Dad].[usp_Joke_Rate]
+    @jokeId        INT,
+    @userRating    INT,
+    @ratingUserKey NVARCHAR(255),
+    @userName      NVARCHAR(255) = N'UNKNOWN'
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    -- ---- Validate parameters -----------------------------------------------
+    IF @jokeId IS NULL OR @jokeId <= 0
+    BEGIN
+        RAISERROR(N'@jokeId must be a positive integer.', 16, 1);
+        RETURN;
+    END
+
+    IF @userRating < 1 OR @userRating > 5
+    BEGIN
+        RAISERROR(N'@userRating must be between 1 and 5.', 16, 1);
+        RETURN;
+    END
+
+    IF @ratingUserKey IS NULL OR LEN(LTRIM(RTRIM(@ratingUserKey))) = 0
+    BEGIN
+        RAISERROR(N'@ratingUserKey must not be empty.', 16, 1);
+        RETURN;
+    END
+
+    IF NOT EXISTS (SELECT 1 FROM [Dad].[Joke] WHERE [JokeId] = @jokeId)
+    BEGIN
+        RAISERROR(N'Joke with the specified @jokeId does not exist.', 16, 1);
+        RETURN;
+    END
+
+    -- ---- Declare output variables ------------------------------------------
+    DECLARE @wasInsert BIT = 0;
+
+    -- ---- Upsert rating ------------------------------------------------------
+    IF EXISTS (
+        SELECT 1
+        FROM [Dad].[JokeRating]
+        WHERE [JokeId] = @jokeId
+          AND [RatingUserKey] = @ratingUserKey
+    )
+    BEGIN
+        -- Update the existing row
+        UPDATE [Dad].[JokeRating]
+        SET    [UserRating]    = @userRating,
+               [CreateUserName] = @userName
+        WHERE  [JokeId]        = @jokeId
+          AND  [RatingUserKey] = @ratingUserKey;
+
+        SET @wasInsert = 0;
+    END
+    ELSE
+    BEGIN
+        -- Insert a new row
+        INSERT INTO [Dad].[JokeRating]
+            ([JokeId], [UserRating], [RatingUserKey], [CreateUserName])
+        VALUES
+            (@jokeId, @userRating, @ratingUserKey, @userName);
+
+        SET @wasInsert = 1;
+    END
+
+    -- ---- Recompute aggregates on the parent Joke row -----------------------
+    UPDATE [Dad].[Joke]
+    SET    [Rating]    = (
+               SELECT AVG(CAST([UserRating] AS DECIMAL(5,2)))
+               FROM   [Dad].[JokeRating]
+               WHERE  [JokeId] = @jokeId
+           ),
+           [VoteCount] = (
+               SELECT COUNT(*)
+               FROM   [Dad].[JokeRating]
+               WHERE  [JokeId] = @jokeId
+           )
+    WHERE  [JokeId] = @jokeId;
+
+    -- ---- Return result row -------------------------------------------------
+    SELECT
+        @jokeId                                         AS [JokeId],
+        @userRating                                     AS [UserRating],
+        (
+            SELECT AVG(CAST([UserRating] AS DECIMAL(5,2)))
+            FROM   [Dad].[JokeRating]
+            WHERE  [JokeId] = @jokeId
+        )                                               AS [AverageRating],
+        (
+            SELECT COUNT(*)
+            FROM   [Dad].[JokeRating]
+            WHERE  [JokeId] = @jokeId
+        )                                               AS [VoteCount],
+        @wasInsert                                      AS [WasInsert];
+END
+GO

--- a/src/sql.database/Dad/Tables/JokeRating.sql
+++ b/src/sql.database/Dad/Tables/JokeRating.sql
@@ -1,11 +1,17 @@
 -- =============================================
 -- Table: JokeRating
--- Description: Stores user ratings for jokes
+-- Description: Stores user ratings for jokes.
+--              RatingUserKey identifies the rater:
+--              - Authenticated users: their identity claim value
+--              - Anonymous users:     ANON_IP_<SHA256 of IP+salt>
+--              The unique index on (JokeId, RatingUserKey) ensures
+--              one rating per user per joke; upsert via usp_Joke_Rate.
 -- =============================================
 CREATE TABLE [Dad].[JokeRating](
 	[JokeRatingId] [int] IDENTITY(1,1) NOT NULL,
 	[JokeId] [int] NOT NULL,
 	[UserRating] [int] NOT NULL,
+	[RatingUserKey] [nvarchar](255) NOT NULL,
 	[CreateDateTime] [datetime] NOT NULL,
 	[CreateUserName] [nvarchar](255) NOT NULL,
  CONSTRAINT [PK_JokeRating] PRIMARY KEY CLUSTERED ([JokeRatingId] ASC)
@@ -16,6 +22,8 @@ GO
 ALTER TABLE [Dad].[JokeRating] ADD CONSTRAINT [DF_JokeRating_CreateDateTime] DEFAULT (getdate()) FOR [CreateDateTime]
 GO
 ALTER TABLE [Dad].[JokeRating] ADD CONSTRAINT [DF_JokeRating_CreateUserName] DEFAULT (N'UNKNOWN') FOR [CreateUserName]
+GO
+ALTER TABLE [Dad].[JokeRating] ADD CONSTRAINT [DF_JokeRating_RatingUserKey] DEFAULT (N'UNKNOWN') FOR [RatingUserKey]
 GO
 
 -- Check constraints
@@ -29,4 +37,9 @@ REFERENCES [Dad].[Joke] ([JokeId])
 	ON DELETE CASCADE
 GO
 ALTER TABLE [Dad].[JokeRating] CHECK CONSTRAINT [FK_JokeRating_Joke]
+GO
+
+-- Unique index: one rating per user key per joke (enables upsert semantics)
+CREATE UNIQUE NONCLUSTERED INDEX [IX_JokeRating_JokeId_RatingUserKey]
+    ON [Dad].[JokeRating] ([JokeId] ASC, [RatingUserKey] ASC)
 GO

--- a/src/sql.database/Patch/Patch-20260706-add-rating-user-key.sql
+++ b/src/sql.database/Patch/Patch-20260706-add-rating-user-key.sql
@@ -1,0 +1,67 @@
+-- =============================================
+-- Migration Patch: Add RatingUserKey to JokeRating
+-- Date: 2026-07-06
+-- Description: Adds the RatingUserKey column and unique index needed for the
+--              per-user joke rating feature.  Backfills existing rows with
+--              a legacy sentinel so the unique constraint can be applied.
+--              Script is idempotent: safe to run multiple times.
+-- =============================================
+
+-- 1. Add RatingUserKey column if it does not already exist
+IF NOT EXISTS (
+    SELECT 1
+    FROM   sys.columns c
+    JOIN   sys.objects o ON o.object_id = c.object_id
+    JOIN   sys.schemas s ON s.schema_id = o.schema_id
+    WHERE  s.name = N'Dad'
+      AND  o.name = N'JokeRating'
+      AND  c.name = N'RatingUserKey'
+)
+BEGIN
+    ALTER TABLE [Dad].[JokeRating]
+        ADD [RatingUserKey] NVARCHAR(255) NOT NULL
+            CONSTRAINT [DF_JokeRating_RatingUserKey] DEFAULT (N'UNKNOWN');
+
+    PRINT 'Column RatingUserKey added.';
+END
+ELSE
+BEGIN
+    PRINT 'Column RatingUserKey already exists — skipping ALTER TABLE.';
+END
+GO
+
+-- 2. Backfill existing rows that still carry the default 'UNKNOWN' key.
+--    Rows that came from the old schema all collide on the same key; make
+--    each one unique so the constraint below can be applied cleanly.
+--    New key format:  ANON_LEGACY_<JokeRatingId>
+UPDATE [Dad].[JokeRating]
+SET    [RatingUserKey] = N'ANON_LEGACY_' + CAST([JokeRatingId] AS NVARCHAR(20))
+WHERE  [RatingUserKey] = N'UNKNOWN';
+
+PRINT CAST(@@ROWCOUNT AS NVARCHAR(10)) + ' legacy rows backfilled.';
+GO
+
+-- 3. Add the unique index if it does not already exist
+IF NOT EXISTS (
+    SELECT 1
+    FROM   sys.indexes i
+    JOIN   sys.objects o ON o.object_id = i.object_id
+    JOIN   sys.schemas s ON s.schema_id = o.schema_id
+    WHERE  s.name = N'Dad'
+      AND  o.name = N'JokeRating'
+      AND  i.name = N'IX_JokeRating_JokeId_RatingUserKey'
+)
+BEGIN
+    CREATE UNIQUE NONCLUSTERED INDEX [IX_JokeRating_JokeId_RatingUserKey]
+        ON [Dad].[JokeRating] ([JokeId] ASC, [RatingUserKey] ASC);
+
+    PRINT 'Unique index IX_JokeRating_JokeId_RatingUserKey created.';
+END
+ELSE
+BEGIN
+    PRINT 'Unique index already exists — skipping.';
+END
+GO
+
+PRINT 'Patch Patch-20260706-add-rating-user-key complete.';
+GO

--- a/src/web/Data/DadABaseDbContext.cs
+++ b/src/web/Data/DadABaseDbContext.cs
@@ -45,6 +45,11 @@ public class DadABaseDbContext(DbContextOptions<DadABaseDbContext> options) : Db
     public DbSet<JokeJokeCategory>? JokeJokeCategories { get; set; }
 
     /// <summary>
+    /// Gets or sets the keyless result type for stored procedure usp_Joke_Rate output.
+    /// </summary>
+    public DbSet<JokeRatingResult>? JokeRatingResults { get; set; }
+
+    /// <summary>
     /// Configures the schema needed for the DadABase context.
     /// </summary>
     /// <param name="modelBuilder">The builder being used to construct the model for this context.</param>
@@ -60,5 +65,8 @@ public class DadABaseDbContext(DbContextOptions<DadABaseDbContext> options) : Db
         // Configure composite key for JokeJokeCategory
         modelBuilder.Entity<JokeJokeCategory>()
             .HasKey(jjc => new { jjc.JokeId, jjc.JokeCategoryId });
+
+        // Register keyless entity for stored procedure result
+        modelBuilder.Entity<JokeRatingResult>().HasNoKey();
     }
 }

--- a/src/web/Data/Models/JokeRating.cs
+++ b/src/web/Data/Models/JokeRating.cs
@@ -65,6 +65,18 @@ public class JokeRating
     public DateTime CreateDateTime { get; set; }
 
     /// <summary>
+    /// Gets or sets the opaque rating user key that uniquely identifies the rater.
+    /// Authenticated users: their identity claim value.
+    /// Anonymous users: "ANON_IP_" followed by a SHA-256 hash of the client IP and an app salt.
+    /// Together with <see cref="JokeId"/>, this forms the unique constraint that enforces
+    /// one rating per user per joke.
+    /// </summary>
+    /// <value>A non-empty string identifying the rater; never a raw IP address.</value>
+    [Display(Name = "Rating User Key", Description = "Opaque key identifying the rater.", Prompt = "Enter Rating User Key")]
+    [StringLength(255)]
+    public string RatingUserKey { get; set; } = "UNKNOWN";
+
+    /// <summary>
     /// Gets or sets the name of the user who created the record.
     /// </summary>
     /// <value>
@@ -82,6 +94,7 @@ public class JokeRating
         JokeRatingId = 0;
         JokeId = 0;
         UserRating = 0;
+        RatingUserKey = "UNKNOWN";
         CreateUserName = "UNKNOWN";
         CreateDateTime = DateTime.UtcNow;
     }
@@ -95,6 +108,7 @@ public class JokeRating
         JokeRatingId = 0;
         JokeId = jokeId;
         UserRating = 0;
+        RatingUserKey = "UNKNOWN";
         CreateUserName = "UNKNOWN";
         CreateDateTime = DateTime.UtcNow;
     }
@@ -109,7 +123,24 @@ public class JokeRating
         JokeRatingId = 0;
         JokeId = jokeId;
         UserRating = userRating;
+        RatingUserKey = "UNKNOWN";
         CreateUserName = "UNKNOWN";
+        CreateDateTime = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JokeRating"/> class with a rating user key.
+    /// </summary>
+    /// <param name="jokeId">The associated joke identifier.</param>
+    /// <param name="userRating">The user rating value.</param>
+    /// <param name="ratingUserKey">The opaque key identifying the rater.</param>
+    public JokeRating(int jokeId, int userRating, string ratingUserKey)
+    {
+        JokeRatingId = 0;
+        JokeId = jokeId;
+        UserRating = userRating;
+        RatingUserKey = ratingUserKey ?? "UNKNOWN";
+        CreateUserName = ratingUserKey ?? "UNKNOWN";
         CreateDateTime = DateTime.UtcNow;
     }
 }

--- a/src/web/Data/Models/JokeRatingResult.cs
+++ b/src/web/Data/Models/JokeRatingResult.cs
@@ -1,0 +1,33 @@
+//-----------------------------------------------------------------------
+// <copyright file="JokeRatingResult.cs" company="Luppes Consulting, Inc.">
+// Copyright 2026, Luppes Consulting, Inc. All rights reserved.
+// </copyright>
+// <summary>
+// Keyless result type returned by the [Dad].[usp_Joke_Rate] stored procedure.
+// </summary>
+//-----------------------------------------------------------------------
+namespace DadABase.Data.Models;
+
+/// <summary>
+/// Represents the single-row result set returned by <c>[Dad].[usp_Joke_Rate]</c>.
+/// Mapped as a keyless entity so EF Core can materialise it from a raw SQL query.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[Keyless]
+public class JokeRatingResult
+{
+    /// <summary>Gets or sets the joke identifier.</summary>
+    public int JokeId { get; set; }
+
+    /// <summary>Gets or sets the star value that was persisted (1–5).</summary>
+    public int UserRating { get; set; }
+
+    /// <summary>Gets or sets the recomputed average rating for the joke.</summary>
+    public decimal AverageRating { get; set; }
+
+    /// <summary>Gets or sets the recomputed total vote count for the joke.</summary>
+    public int VoteCount { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether a new row was inserted (<see langword="true"/>) or an existing row updated (<see langword="false"/>).</summary>
+    public bool WasInsert { get; set; }
+}

--- a/src/web/Data/Repositories/IJokeRepository.cs
+++ b/src/web/Data/Repositories/IJokeRepository.cs
@@ -175,6 +175,49 @@ public interface IJokeRepository
     bool DeleteJoke(int jokeId, string requestingUserName = "ANON");
 
     /// <summary>
+    /// Submits or updates a star rating (1–5) for a joke from a specific user key.
+    /// If a rating already exists for the (jokeId, ratingUserKey) pair it is updated;
+    /// otherwise a new row is inserted.  The parent Joke's aggregated Rating and
+    /// VoteCount are recomputed after the upsert.
+    /// </summary>
+    /// <param name="jokeId">The identifier of the joke being rated.</param>
+    /// <param name="userRating">The star rating value (1–5 inclusive).</param>
+    /// <param name="ratingUserKey">
+    /// Opaque key identifying the rater.
+    /// Authenticated users: their identity claim value.
+    /// Anonymous users: "ANON_IP_" + SHA-256(clientIP + salt).
+    /// </param>
+    /// <param name="requestingUserName">Display name stored in the audit column. Defaults to "ANON".</param>
+    /// <returns>
+    /// A tuple containing:
+    /// <list type="bullet">
+    ///   <item><c>Success</c> – whether the operation succeeded.</item>
+    ///   <item><c>UserRating</c> – the persisted star value.</item>
+    ///   <item><c>AverageRating</c> – updated aggregate average.</item>
+    ///   <item><c>VoteCount</c> – updated total vote count.</item>
+    ///   <item><c>WasInsert</c> – true if a new row was created, false if an existing row was updated.</item>
+    /// </list>
+    /// </returns>
+    (bool Success, int UserRating, decimal AverageRating, int VoteCount, bool WasInsert) SubmitOrUpdateRating(
+        int jokeId, int userRating, string ratingUserKey, string requestingUserName = "ANON");
+
+    /// <summary>
+    /// Returns the current star rating that a specific user key has given to a joke,
+    /// or <see langword="null"/> if the user has not yet rated that joke.
+    /// </summary>
+    /// <param name="jokeId">The identifier of the joke.</param>
+    /// <param name="ratingUserKey">The opaque key identifying the rater.</param>
+    /// <returns>The persisted rating (1–5), or <see langword="null"/> if not rated.</returns>
+    int? GetUserRatingForJoke(int jokeId, string ratingUserKey);
+
+    /// <summary>
+    /// Returns the current aggregate rating summary for a joke.
+    /// </summary>
+    /// <param name="jokeId">The identifier of the joke.</param>
+    /// <returns>A tuple of (AverageRating, VoteCount).</returns>
+    (decimal AverageRating, int VoteCount) GetRatingSummaryForJoke(int jokeId);
+
+    /// <summary>
     /// Disposal
     /// </summary>
     void Dispose();

--- a/src/web/Data/Repositories/JokeJsonRepository.cs
+++ b/src/web/Data/Repositories/JokeJsonRepository.cs
@@ -28,6 +28,12 @@ public class JokeJsonRepository : IJokeRepository
     private readonly List<string> _jokeCategories;
 
     /// <summary>
+    /// In-memory store for joke ratings keyed by (JokeId, RatingUserKey).
+    /// Provides the same upsert-with-aggregate behaviour as the SQL path.
+    /// </summary>
+    private readonly Dictionary<(int JokeId, string RatingUserKey), int> _ratings = new();
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="JokeJsonRepository"/> class.
     /// </summary>
     /// <param name="jsonFilePath">The path to the JSON file that contains the jokes payload.</param>
@@ -519,5 +525,67 @@ public class JokeJsonRepository : IJokeRepository
     public void Dispose()
     {
         // No resources to dispose for JSON-based repository
+    }
+
+    /// <summary>
+    /// Submits or updates a star rating (1–5) for a joke using an in-memory store.
+    /// Behaviour mirrors the SQL implementation: one rating per (JokeId, RatingUserKey);
+    /// aggregate Rating and VoteCount on the parent <see cref="Joke"/> are recomputed.
+    /// </summary>
+    public (bool Success, int UserRating, decimal AverageRating, int VoteCount, bool WasInsert) SubmitOrUpdateRating(
+        int jokeId, int userRating, string ratingUserKey, string requestingUserName = "ANON")
+    {
+        if (userRating < 1 || userRating > 5)
+        {
+            return (false, userRating, 0m, 0, false);
+        }
+
+        var joke = _jokes.FirstOrDefault(j => j.JokeId == jokeId);
+        if (joke == null)
+        {
+            return (false, userRating, 0m, 0, false);
+        }
+
+        var key = (jokeId, ratingUserKey ?? "UNKNOWN");
+        var wasInsert = !_ratings.ContainsKey(key);
+        _ratings[key] = userRating;
+
+        // Recompute aggregates
+        var jokeRatings = _ratings
+            .Where(kv => kv.Key.JokeId == jokeId)
+            .Select(kv => kv.Value)
+            .ToList();
+
+        var avg = jokeRatings.Count > 0 ? (decimal)jokeRatings.Average() : 0m;
+        var count = jokeRatings.Count;
+
+        joke.Rating = avg;
+        joke.VoteCount = count;
+
+        return (true, userRating, avg, count, wasInsert);
+    }
+
+    /// <summary>
+    /// Returns the current star rating a specific user key has given to a joke,
+    /// or <see langword="null"/> if not yet rated.
+    /// </summary>
+    public int? GetUserRatingForJoke(int jokeId, string ratingUserKey)
+    {
+        var key = (jokeId, ratingUserKey ?? "UNKNOWN");
+        return _ratings.TryGetValue(key, out var rating) ? rating : null;
+    }
+
+    /// <summary>
+    /// Returns the current aggregate rating summary for a joke.
+    /// </summary>
+    public (decimal AverageRating, int VoteCount) GetRatingSummaryForJoke(int jokeId)
+    {
+        var joke = _jokes.FirstOrDefault(j => j.JokeId == jokeId);
+        if (joke == null)
+        {
+            return (0m, 0);
+        }
+
+        return (joke.Rating ?? 0m, joke.VoteCount ?? 0);
     }
 }

--- a/src/web/Data/Repositories/JokeSQLRepository.cs
+++ b/src/web/Data/Repositories/JokeSQLRepository.cs
@@ -1070,6 +1070,78 @@ public class JokeSQLRepository(DadABaseDbContext context) : IJokeRepository
     }
 
     /// <summary>
+    /// Submits or updates a star rating for a joke using the usp_Joke_Rate stored procedure.
+    /// </summary>
+    public (bool Success, int UserRating, decimal AverageRating, int VoteCount, bool WasInsert) SubmitOrUpdateRating(
+        int jokeId, int userRating, string ratingUserKey, string requestingUserName = "ANON")
+    {
+        try
+        {
+            var results = _context.JokeRatingResults
+                .FromSqlInterpolated(
+                    $"EXEC [Dad].[usp_Joke_Rate] @jokeId = {jokeId}, @userRating = {userRating}, @ratingUserKey = {ratingUserKey}, @userName = {requestingUserName}")
+                .AsEnumerable()
+                .FirstOrDefault();
+
+            if (results == null)
+            {
+                return (false, userRating, 0m, 0, false);
+            }
+
+            return (true, results.UserRating, results.AverageRating, results.VoteCount, results.WasInsert);
+        }
+        catch (Exception ex)
+        {
+            var msg = Utilities.GetExceptionMessage(ex);
+            Console.WriteLine($"Error submitting rating for joke {jokeId}: {msg}");
+            return (false, userRating, 0m, 0, false);
+        }
+    }
+
+    /// <summary>
+    /// Returns the current star rating that a specific user key has given to a joke.
+    /// </summary>
+    public int? GetUserRatingForJoke(int jokeId, string ratingUserKey)
+    {
+        try
+        {
+            return _context.JokeRatings
+                .Where(r => r.JokeId == jokeId && r.RatingUserKey == ratingUserKey)
+                .Select(r => (int?)r.UserRating)
+                .FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            var msg = Utilities.GetExceptionMessage(ex);
+            Console.WriteLine($"Error fetching user rating for joke {jokeId}: {msg}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Returns the current aggregate rating summary for a joke.
+    /// </summary>
+    public (decimal AverageRating, int VoteCount) GetRatingSummaryForJoke(int jokeId)
+    {
+        try
+        {
+            var joke = _context.Jokes.AsNoTracking().FirstOrDefault(j => j.JokeId == jokeId);
+            if (joke == null)
+            {
+                return (0m, 0);
+            }
+
+            return (joke.Rating ?? 0m, joke.VoteCount ?? 0);
+        }
+        catch (Exception ex)
+        {
+            var msg = Utilities.GetExceptionMessage(ex);
+            Console.WriteLine($"Error fetching rating summary for joke {jokeId}: {msg}");
+            return (0m, 0);
+        }
+    }
+
+    /// <summary>
     /// Disposes the repository and its underlying resources.
     /// </summary>
     public void Dispose()

--- a/src/web/Website/API/JokeController.cs
+++ b/src/web/Website/API/JokeController.cs
@@ -10,6 +10,7 @@ namespace DadABase.API;
 
 using DadABase.Data.Models;
 using DadABase.Data.Repositories;
+using DadABase.Web.Services;
 using Microsoft.AspNetCore.Authorization;
 using RouteAttribute = Microsoft.AspNetCore.Mvc.RouteAttribute;
 
@@ -30,18 +31,25 @@ public class JokeController : BaseAPIController
     public IJokeRepository JokeRepo { get; private set; }
 
     /// <summary>
+    /// Rating user key resolver
+    /// </summary>
+    private readonly RatingUserKeyResolver _ratingKeyResolver;
+
+    /// <summary>
     /// Joke API Controller (for unit tests)
     /// </summary>
     /// <param name="settings">Settings</param>
     /// <param name="contextAccessor">Context</param>
     /// <param name="jokeRepo">Repository</param>
-    public JokeController(AppSettings settings, IHttpContextAccessor contextAccessor, IJokeRepository jokeRepo)
+    /// <param name="ratingKeyResolver">Rating user key resolver</param>
+    public JokeController(AppSettings settings, IHttpContextAccessor contextAccessor, IJokeRepository jokeRepo, RatingUserKeyResolver ratingKeyResolver)
     {
         SetupAutoMapper();
         context = contextAccessor;
         AppSettingsValues = settings;
         AppSettingsValues.UserName = GetUserName();
         JokeRepo = jokeRepo;
+        _ratingKeyResolver = ratingKeyResolver;
     }
     #endregion
 
@@ -130,5 +138,82 @@ public class JokeController : BaseAPIController
         var jokes = JokeRepo.SearchJokes(searchTxt, categoryTxt, userName);
         var simplifiedJokes = iMapper.Map<IEnumerable<Joke>, List<JokeBasic>>(jokes);
         return simplifiedJokes;
+    }
+
+    /// <summary>
+    /// Submit or update a star rating (1–5) for a joke.
+    /// Authenticated users are identified by their identity claim.
+    /// Anonymous users are identified by a hash of their client IP.
+    /// </summary>
+    /// <param name="request">Rating request containing JokeId and UserRating.</param>
+    /// <returns>Updated rating details.</returns>
+    [HttpPost]
+    [Route("rate")]
+    [AllowAnonymous]
+    public IActionResult Rate([FromBody] JokeRateRequest request)
+    {
+        if (request == null || request.JokeId <= 0 || request.UserRating < 1 || request.UserRating > 5)
+        {
+            return BadRequest(new { error = "JokeId must be positive and UserRating must be 1–5." });
+        }
+
+        var userName = GetUserName();
+        var ratingKey = _ratingKeyResolver.Resolve(context?.HttpContext);
+
+        var (success, userRating, averageRating, voteCount, wasInsert) =
+            JokeRepo.SubmitOrUpdateRating(request.JokeId, request.UserRating, ratingKey, userName);
+
+        if (!success)
+        {
+            return StatusCode(500, new { error = "Rating could not be saved." });
+        }
+
+        return Ok(new
+        {
+            jokeId = request.JokeId,
+            userRating,
+            averageRating,
+            voteCount,
+            wasInsert
+        });
+    }
+
+    /// <summary>
+    /// Returns the aggregate rating summary (average and vote count) for a joke.
+    /// </summary>
+    /// <param name="id">The joke identifier.</param>
+    /// <returns>Average rating and vote count.</returns>
+    [HttpGet]
+    [Route("{id}/rating/summary")]
+    [AllowAnonymous]
+    public IActionResult RatingSummary(int id)
+    {
+        if (id <= 0)
+        {
+            return BadRequest(new { error = "Invalid joke id." });
+        }
+
+        var (averageRating, voteCount) = JokeRepo.GetRatingSummaryForJoke(id);
+        return Ok(new { jokeId = id, averageRating, voteCount });
+    }
+
+    /// <summary>
+    /// Returns the current user's rating for a specific joke, or null if not yet rated.
+    /// </summary>
+    /// <param name="id">The joke identifier.</param>
+    /// <returns>The current user's rating (1–5) or null.</returns>
+    [HttpGet]
+    [Route("{id}/rating/current")]
+    [AllowAnonymous]
+    public IActionResult UserRating(int id)
+    {
+        if (id <= 0)
+        {
+            return BadRequest(new { error = "Invalid joke id." });
+        }
+
+        var ratingKey = _ratingKeyResolver.Resolve(context?.HttpContext);
+        var rating = JokeRepo.GetUserRatingForJoke(id, ratingKey);
+        return Ok(new { jokeId = id, userRating = rating });
     }
 }

--- a/src/web/Website/Components/JokeDisplayComponent.razor
+++ b/src/web/Website/Components/JokeDisplayComponent.razor
@@ -14,32 +14,16 @@
                 @((MarkupString)myFullText)
             </div>
         </div>
+        @if (!string.IsNullOrEmpty(myFullText))
+        {
+            <div class="joke-rating">
+                <MudRating SelectedValue="@displayRatingValue" MaxValue="5" Color="Color.Primary"
+                           SelectedValueChanged="OnRatingChanged" />
+                @if (ratingSubmitting)
+                {
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">Saving...</MudText>
+                }
+            </div>
+        }
     </div>
-        @*
-        <AuthorizeView Roles="Admin">
-            @if (!showJokeEditor)
-            {
-                <button @onclick="ShowJokeEditor" class="EditButton"><i class="fa fa-edit" /></button>
-            }
-        </AuthorizeView>
-        <div class="JokeText">
-             @if (showJokeEditor)
-            {
-                <JokeEditComponent JokeToEdit="@editJoke" OnSave="JokeEditorSave" OnCancel="JokeEditorCancel" />
-            }
-            else {
-                @((MarkupString)myFullText)
-            }
-            <br />
-        </div>
-   </div>
-        *@
-   @*
-    @if (supportsRatings && !string.IsNullOrEmpty(myFullText))
-    {
-        <div>
-            <MudRating @bind-SelectedValue="@displayRatingValue" MaxValue="5" Color="Color.Primary" />
-        </div>
-    }
-    *@
 }

--- a/src/web/Website/Components/JokeDisplayComponent.razor.cs
+++ b/src/web/Website/Components/JokeDisplayComponent.razor.cs
@@ -20,16 +20,15 @@ public partial class JokeDisplayComponent : ComponentBase
     public Joke myJoke { get; set; }
 
     [Inject] IJokeRepository JokeRepository { get; set; }
-    [Inject] HttpContextAccessor Context { get; set; }
+    [Inject] IHttpContextAccessor HttpContextAccessor { get; set; }
     [Inject] SweetAlertService SweetAlert { get; set; }
     [Inject] ISnackbar Snackbar { get; set; }
+    [Inject] DadABase.Web.Services.RatingUserKeyResolver RatingKeyResolver { get; set; }
 
     private string myJokeText = string.Empty;
     private string myFullText = string.Empty;
-    //private int displayRatingValue = 0;
-    //private bool supportsRatings = false;
-    // private bool showJokeEditor = false;
-    // private Joke editJoke = new Joke();
+    private int displayRatingValue = 0;
+    private bool ratingSubmitting = false;
 
     /// <summary>
     /// Recomputes the display text when parameter values change.
@@ -47,10 +46,7 @@ public partial class JokeDisplayComponent : ComponentBase
     {
         if (string.IsNullOrEmpty(joke.JokeTxt) || myJokeText == joke.JokeTxt) return;
 
-        //JokeEditorCancel();
-
-        // supportsRatings = joke.Rating != null;
-        // displayRatingValue = joke.Rating != null ? Convert.ToInt16(Math.Round((decimal)joke.Rating)) : 0;
+        displayRatingValue = joke.Rating != null ? Convert.ToInt32(Math.Round((decimal)joke.Rating)) : 0;
 
         myJokeText = System.Web.HttpUtility.HtmlEncode(joke.JokeTxt);
         myJokeText = myJokeText.Replace("\n", "<br/>");
@@ -81,42 +77,51 @@ public partial class JokeDisplayComponent : ComponentBase
         }
     }
 
-    // private async Task SubmitRating(MouseEventArgs e)
-    // {
-    //     var oldValue = myJoke.Rating != null ? Convert.ToInt16(Math.Round((decimal)myJoke.Rating)) : 0;
-    //     var newValue = displayRatingValue;
-    //     var newJokeRatingRecord = new JokeRating(myJoke.JokeId, displayRatingValue);
-    //     var userIdentity = Context.HttpContext.User;
-    //     var userName = userIdentity != null ? userIdentity.Identity.Name : "ANON";
-    //     var newAverageRatingValue = JokeRepository.AddRating(newJokeRatingRecord, userName);
-    //     displayRatingValue = Convert.ToInt16(Math.Round(newAverageRatingValue));
-    //     Snackbar.Add($"Your Rating: {newValue}, Average Rating: {newAverageRatingValue}", Severity.Info);
-    //     _ = await Task.FromResult(true);
-    // }
+    /// <summary>
+    /// Handles a new star rating selection from the MudRating control.
+    /// </summary>
+    /// <param name="newValue">The newly selected star value (1–5).</param>
+    private async Task OnRatingChanged(int newValue)
+    {
+        if (myJoke == null || newValue < 1 || newValue > 5 || ratingSubmitting)
+        {
+            return;
+        }
 
-    // private async Task ShowJokeEditor()
-    // {
-    //     showJokeEditor = !showJokeEditor;
-    //     editJoke = new Joke();
-    //     editJoke.JokeId = myJoke.JokeId;
-    //     editJoke.JokeTxt = myJoke.JokeTxt;
-    //     editJoke.JokeTxt = myJoke.JokeTxt;
-    //     Snackbar.Add($"Editor is not complete and changes will not be saved!", Severity.Warning);
-    //     _ = await Task.FromResult(true);
-    // }
-    // private async void JokeEditorSave()
-    // {
-    //     myJoke.JokeId = editJoke.JokeId;
-    //     myJoke.JokeTxt = editJoke.JokeTxt;
-    //     // TODO: put code here to update the database...
-    //     // HOWEVER... the current edit form blows away all the line breaks and other formatting so it's not ready for prime time...!
-    //     Snackbar.Add("This feature is not complete and the edits have NOT been saved!", Severity.Error);
-    //     showJokeEditor = !showJokeEditor;
-    // }
-    // private void JokeEditorCancel()
-    // {
-    //     editJoke.JokeId = 0;
-    //     editJoke.JokeTxt = string.Empty;
-    //     showJokeEditor = false;
-    // }
+        displayRatingValue = newValue;
+        ratingSubmitting = true;
+        StateHasChanged();
+
+        try
+        {
+            var ratingKey = RatingKeyResolver.Resolve(HttpContextAccessor?.HttpContext);
+            var userName = HttpContextAccessor?.HttpContext?.User?.Identity?.Name ?? "ANON";
+
+            var (success, _, averageRating, voteCount, wasInsert) =
+                JokeRepository.SubmitOrUpdateRating(myJoke.JokeId, newValue, ratingKey, userName);
+
+            if (success)
+            {
+                myJoke.Rating = averageRating;
+                myJoke.VoteCount = voteCount;
+                var action = wasInsert ? "Rating saved" : "Rating updated";
+                Snackbar.Add($"{action}: {newValue} ★  |  Average: {averageRating:F1} ({voteCount} votes)", Severity.Success);
+            }
+            else
+            {
+                Snackbar.Add("Could not save your rating. Please try again.", Severity.Error);
+            }
+        }
+        catch
+        {
+            Snackbar.Add("An error occurred while saving your rating.", Severity.Error);
+        }
+        finally
+        {
+            ratingSubmitting = false;
+            StateHasChanged();
+        }
+
+        await Task.CompletedTask;
+    }
 }

--- a/src/web/Website/Models/ViewModels/JokeRateRequest.cs
+++ b/src/web/Website/Models/ViewModels/JokeRateRequest.cs
@@ -1,0 +1,26 @@
+//-----------------------------------------------------------------------
+// <copyright file="JokeRateRequest.cs" company="Luppes Consulting, Inc.">
+// Copyright 2026, Luppes Consulting, Inc. All rights reserved.
+// </copyright>
+// <summary>
+// Request body for POST /api/joke/rate
+// </summary>
+//-----------------------------------------------------------------------
+namespace DadABase.Data;
+
+/// <summary>
+/// Request body for the joke rate endpoint.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class JokeRateRequest
+{
+    /// <summary>
+    /// Gets or sets the identifier of the joke to rate.
+    /// </summary>
+    public int JokeId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the star rating value (1–5 inclusive).
+    /// </summary>
+    public int UserRating { get; set; }
+}

--- a/src/web/Website/Program.cs
+++ b/src/web/Website/Program.cs
@@ -113,6 +113,7 @@ builder.Services.AddSingleton<IJokeImageQueue, JokeImageQueue>();
 builder.Services.AddHostedService<JokeImageQueueService>();
 builder.Services.AddScoped<IBuildInfoService, BuildInfoService>();
 builder.Services.AddScoped<DadABase.Web.Repositories.ThemeService>();
+builder.Services.AddScoped<DadABase.Web.Services.RatingUserKeyResolver>();
 
 // ----- Configure Authentication ---------------------------------------------------------------------
 var authSettings = builder.Configuration.GetSection("AzureAD");

--- a/src/web/Website/Services/RatingUserKeyResolver.cs
+++ b/src/web/Website/Services/RatingUserKeyResolver.cs
@@ -1,0 +1,125 @@
+//-----------------------------------------------------------------------
+// <copyright file="RatingUserKeyResolver.cs" company="Luppes Consulting, Inc.">
+// Copyright 2026, Luppes Consulting, Inc. All rights reserved.
+// </copyright>
+// <summary>
+// Resolves a stable, opaque user key suitable for identifying the rater of a joke.
+// Authenticated users receive their identity claim value.
+// Anonymous users receive a deterministic prefix + SHA-256 hash derived from the
+// client IP address and an application-level salt — never the raw IP itself.
+// </summary>
+//-----------------------------------------------------------------------
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DadABase.Web.Services;
+
+/// <summary>
+/// Resolves a stable, opaque key that identifies a joke rater.
+/// </summary>
+/// <remarks>
+/// <para>For authenticated users the key is the identity name from the claims principal.</para>
+/// <para>
+/// For anonymous users the key takes the form <c>ANON_IP_&lt;hex&gt;</c> where
+/// <c>&lt;hex&gt;</c> is the lower-case SHA-256 of (normalised IP + salt).
+/// The raw IP address is never stored, satisfying basic PII hygiene.
+/// </para>
+/// <para>
+/// Different anonymous callers from different IPs produce different keys, so the
+/// unique-per-joke constraint in the database allows them to rate independently.
+/// A shared NAT address will be treated as a single rater — an acceptable limitation
+/// for a non-critical feature.
+/// </para>
+/// </remarks>
+public class RatingUserKeyResolver
+{
+    // Salt injected via appsettings to make the hash non-reversible.
+    // Defaults to a fixed value so the service works without explicit configuration.
+    private readonly string _salt;
+
+    /// <summary>
+    /// Initialises the resolver.
+    /// </summary>
+    /// <param name="configuration">The application configuration.</param>
+    public RatingUserKeyResolver(IConfiguration configuration)
+    {
+        _salt = configuration["RatingUserKeySalt"] ?? "dadabase-rating-default-salt-2026";
+    }
+
+    /// <summary>
+    /// Returns the rating user key for the given HTTP context.
+    /// </summary>
+    /// <param name="httpContext">The current <see cref="HttpContext"/>.</param>
+    /// <returns>
+    /// Identity claim value for authenticated users; "ANON_IP_&lt;hash&gt;" for anonymous.
+    /// </returns>
+    public string Resolve(HttpContext httpContext)
+    {
+        if (httpContext == null)
+        {
+            return "ANON_UNKNOWN";
+        }
+
+        // --- Authenticated user ---
+        var user = httpContext.User;
+        if (user?.Identity?.IsAuthenticated == true)
+        {
+            var name = user.Identity.Name;
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                // Strip AAD domain prefix (#) as BaseAPIController does
+                var hash = name.IndexOf('#');
+                return hash >= 0 ? name[(hash + 1)..] : name;
+            }
+        }
+
+        // --- Anonymous user: hash the client IP ---
+        var ip = ResolveClientIp(httpContext);
+        return "ANON_IP_" + HashIp(ip, _salt);
+    }
+
+    // Resolves the client IP, honouring X-Forwarded-For when the connection
+    // comes from a loopback (trusted reverse proxy on the same host).
+    private static string ResolveClientIp(HttpContext httpContext)
+    {
+        var remoteIp = httpContext.Connection.RemoteIpAddress;
+
+        // Only trust X-Forwarded-For when the direct connection is loopback
+        // (i.e. a local reverse proxy), to guard against header spoofing.
+        if (remoteIp != null && IPAddress.IsLoopback(remoteIp))
+        {
+            var forwarded = httpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(forwarded))
+            {
+                // X-Forwarded-For may be a comma-separated list; take the first entry.
+                var firstIp = forwarded.Split(',')[0].Trim();
+                if (IPAddress.TryParse(firstIp, out var parsed))
+                {
+                    return NormaliseIp(parsed);
+                }
+            }
+        }
+
+        return remoteIp != null ? NormaliseIp(remoteIp) : "unknown";
+    }
+
+    // Map IPv4-mapped IPv6 addresses (::ffff:x.x.x.x) to their IPv4 form.
+    private static string NormaliseIp(IPAddress ip)
+    {
+        if (ip.IsIPv4MappedToIPv6)
+        {
+            return ip.MapToIPv4().ToString();
+        }
+
+        return ip.ToString();
+    }
+
+    // SHA-256(ip + salt) → lower-case hex string (64 chars, no PII).
+    private static string HashIp(string ip, string salt)
+    {
+        var input = Encoding.UTF8.GetBytes(ip + salt);
+        var hashBytes = SHA256.HashData(input);
+        return Convert.ToHexString(hashBytes).ToLowerInvariant();
+    }
+}


### PR DESCRIPTION
This pull request introduces the design and foundational implementation for a robust joke rating system, allowing both authenticated and anonymous users to rate jokes with 1–5 stars, ensuring one rating per joke per user (using a unique identity key). It includes a comprehensive implementation plan, a detailed task breakdown, and the initial database and stored procedure changes to enforce rating uniqueness and aggregate computation.

**Key changes include:**

**Design and Implementation Planning**
- Added `Joke-Rating-Implementation-Plan.md` outlining requirements, identity key strategy (authenticated vs. hashed anonymous IP), database and application changes, API and UI integration, testing, and security considerations.
- Added `Joke-Rating-Implementation-Tasks.md` with a phase-by-phase task breakdown, file locations, acceptance criteria, and estimated dev effort for each step.

**Database Schema and Constraints**
- Updated `JokeRating` table to add a new `RatingUserKey` column (with default and documentation), which is used to uniquely identify the rater (authenticated or anonymous). [[1]](diffhunk://#diff-faa2fa295d8435ad2efbe2ed23d28cd70094edd5edca2ea3d5650bfa5ee686f1L3-R14) [[2]](diffhunk://#diff-faa2fa295d8435ad2efbe2ed23d28cd70094edd5edca2ea3d5650bfa5ee686f1R26-R27)
- Added a unique index on `(JokeId, RatingUserKey)` to ensure one rating per user per joke and support upsert semantics.

**Stored Procedure for Upsert and Aggregation**
- Created `usp_Joke_Rate` stored procedure to upsert a rating (insert or update as needed), recompute the joke's average rating and vote count, and return the updated aggregates and operation type.

These changes lay the groundwork for the full-stack joke rating feature, enforcing correct rating behavior and data integrity at the database level, and providing a clear roadmap for repository, API, UI, and testing work.